### PR TITLE
Fix parsing of AWS secret access keys that contain slash (/)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ notifications:
     on_failure: always
 language: python
 python:
-  - "3.7"
   - "3.8"
+  - "3.9"
 cache: pip
 install:
   - pip install pylint

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="b3u",
-    version="1.0.0",
+    version="1.0.1",
     packages=["b3u",],
     install_requires=[],
     license="MIT",


### PR DESCRIPTION
I decided we shouldn't leave this up to consumers of the library, since we're running into issues if for example the credentials are pulled from environment variables, and are both used to connect to boto3 automatically as well as parse a URI through b3u.